### PR TITLE
Update the Node.js version to 20

### DIFF
--- a/wasm-tools/setup/action.yml
+++ b/wasm-tools/setup/action.yml
@@ -10,5 +10,5 @@ inputs:
     required: false
     description: 'When downloading wasm-tools, GitHub may rate limit anonymous downloads. Set this to use authenticated downloads, which are are subject to a higher limits.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: '../../dist/wasm-tools/setup/index.js'

--- a/wasmtime/setup/action.yml
+++ b/wasmtime/setup/action.yml
@@ -10,5 +10,5 @@ inputs:
     required: false
     description: 'When downloading wasmtime, GitHub may rate limit anonymous downloads. Set this to use authenticated downloads, which are are subject to a higher limits.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: '../../dist/wasmtime/setup/index.js'

--- a/wit-bindgen/setup/action.yml
+++ b/wit-bindgen/setup/action.yml
@@ -10,5 +10,5 @@ inputs:
     required: false
     description: 'When downloading wit-bindgen, GitHub may rate limit anonymous downloads. Set this to use authenticated downloads, which are are subject to a higher limits.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: '../../dist/wit-bindgen/setup/index.js'


### PR DESCRIPTION
Node.js 16 is already EOL, and GHA plans to complete the transition by Spring 2024. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/