### PR TITLE
wasm-tools: load new tag format

### DIFF
--- a/.github/workflows/wasm-tools-tests.yml
+++ b/.github/workflows/wasm-tools-tests.yml
@@ -1,4 +1,4 @@
-name: setup wasm-tools e2e tests
+name: wasm-tools
 on:
   pull_request:
     branches: [main]
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 19
-      
+
       - name: npm install
         run: npm install
 
@@ -32,7 +32,7 @@ jobs:
           name: setup-wasm-tools
           path: dist/wasm-tools/setup/index.js
 
-  setup-default-wasm-tools:
+  setup-default:
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
@@ -55,11 +55,12 @@ jobs:
       - name: verify wasm-tools setup
         run: wasm-tools --version
 
-  setup-specific-wasm-tools-version:
+  setup-version:
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        version: ["1.0.43", "1.200.0"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
@@ -73,15 +74,47 @@ jobs:
       - name: setup wasm-tools
         uses: ./wasm-tools/setup/
         with:
-          version: "1.0.43"
+          version: ${{ matrix.version }}
           github_token: ${{ github.token }}
 
       - name: wasm-tools setup successful
-        if: ${{ contains(env.WASM_TOOLS_VERSION, '1.0.43') }}
+        if: ${{ contains(env.WASM_TOOLS_VERSION, matrix.version) }}
         run: echo "wasm-tools setup successful"
 
       - name: wasm-tools setup failed
-        if: ${{ !contains(env.WASM_TOOLS_VERSION, '1.0.43') }}
+        if: ${{ !contains(env.WASM_TOOLS_VERSION, matrix.version) }}
         run: |
-          echo "expected version: 1.0.43, found: ${{ env.WASM_TOOLS_VERSION }}"
+          echo "expected version: ${{ matrix.version }}, found: ${{ env.WASM_TOOLS_VERSION }}"
+          exit 1
+
+  setup-v-version:
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version: ["1.0.43", "1.200.0"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Retrieve saved Github action
+        uses: actions/download-artifact@v3
+        with:
+          name: setup-wasm-tools
+          path: dist/wasm-tools/setup/
+
+      - name: setup wasm-tools with v-prefixed version
+        uses: ./wasm-tools/setup/
+        with:
+          version: v${{ matrix.version }}
+          github_token: ${{ github.token }}
+
+      - name: wasm-tools setup successful
+        if: ${{ contains(env.WASM_TOOLS_VERSION, matrix.version) }}
+        run: echo "wasm-tools setup successful"
+
+      - name: wasm-tools setup failed
+        if: ${{ !contains(env.WASM_TOOLS_VERSION, matrix.version) }}
+        run: |
+          echo "expected version: ${{ matrix.version }}, found: ${{ env.WASM_TOOLS_VERSION }}"
           exit 1

--- a/.github/workflows/wasmtime-tests.yml
+++ b/.github/workflows/wasmtime-tests.yml
@@ -1,4 +1,4 @@
-name: setup wasmtime e2e tests
+name: wasmtime
 on:
   pull_request:
     branches: [main]
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 19
-      
+
       - name: npm install
         run: npm install
 
@@ -32,7 +32,7 @@ jobs:
           name: setup-wasmtime
           path: dist/wasmtime/setup/index.js
 
-  setup-default-wasmtime:
+  setup-default:
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
@@ -55,11 +55,12 @@ jobs:
       - name: verify wasmtime setup
         run: wasmtime --version
 
-  setup-specific-wasmtime-version:
+  setup-version:
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        version: ["12.0.0", "17.0.0"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
@@ -73,15 +74,53 @@ jobs:
       - name: setup wasmtime
         uses: ./wasmtime/setup/
         with:
-          version: "v12.0.0"
+          version: ${{ matrix.version }}
+          github_token: ${{ github.token }}
+
+      - name: setup wasmtime with v
+        uses: ./wasmtime/setup/
+        with:
+          version: v${{ matrix.version }}
           github_token: ${{ github.token }}
 
       - name: wasmtime setup successful
-        if: ${{ contains(env.WASMTIME_VERSION, '12.0.0') }}
+        if: ${{ contains(env.WASMTIME_VERSION, matrix.version) }}
         run: echo "wasmtime setup successful"
 
       - name: wasmtime setup failed
-        if: ${{ !contains(env.WASMTIME_VERSION, '12.0.0') }}
+        if: ${{ !contains(env.WASMTIME_VERSION, matrix.version) }}
         run: |
-          echo "expected version: 12.0.0, found: ${{ env.WASMTIME_VERSION }}"
+          echo "expected version: ${{ matrix.version }}, found: ${{ env.WASMTIME_VERSION }}"
+          exit 1
+
+  setup-v-version:
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version: ["12.0.0", "17.0.0"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Retrieve saved Github action
+        uses: actions/download-artifact@v3
+        with:
+          name: setup-wasmtime
+          path: dist/wasmtime/setup/
+
+      - name: setup wasmtime with v-prefixed version
+        uses: ./wasmtime/setup/
+        with:
+          version: v${{ matrix.version }}
+          github_token: ${{ github.token }}
+
+      - name: wasmtime setup successful
+        if: ${{ contains(env.WASMTIME_VERSION, matrix.version) }}
+        run: echo "wasmtime setup successful"
+
+      - name: wasmtime setup failed
+        if: ${{ !contains(env.WASMTIME_VERSION, matrix.version) }}
+        run: |
+          echo "expected version: ${{ matrix.version }}, found: ${{ env.WASMTIME_VERSION }}"
           exit 1

--- a/.github/workflows/wit-bindgen-tests.yml
+++ b/.github/workflows/wit-bindgen-tests.yml
@@ -1,4 +1,4 @@
-name: setup wit-bindgen e2e tests
+name: wit-bindgen
 on:
   pull_request:
     branches: [main]
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 19
-      
+
       - name: npm install
         run: npm install
 
@@ -32,7 +32,7 @@ jobs:
           name: setup-wit-bindgen
           path: dist/wit-bindgen/setup/index.js
 
-  setup-default-wit-bindgen:
+  setup-default:
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
@@ -55,11 +55,12 @@ jobs:
       - name: verify wit-bindgen setup
         run: wit-bindgen --version
 
-  setup-specific-wit-bindgen-version:
+  setup-version:
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        version: ["0.16.0", "0.19.0"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
@@ -73,15 +74,47 @@ jobs:
       - name: setup wit-bindgen
         uses: ./wit-bindgen/setup/
         with:
-          version: "0.16.0"
+          version: ${{ matrix.version }}
           github_token: ${{ github.token }}
 
       - name: wit-bindgen setup successful
-        if: ${{ contains(env.WIT_BINDGEN_VERSION, '0.16.0') }}
+        if: ${{ contains(env.WIT_BINDGEN_VERSION, matrix.version) }}
         run: echo "wit-bindgen setup successful"
 
       - name: wit-bindgen setup failed
-        if: ${{ !contains(env.WIT_BINDGEN_VERSION, '0.16.0') }}
+        if: ${{ !contains(env.WIT_BINDGEN_VERSION, matrix.version) }}
         run: |
-          echo "expected version: 0.16.0, found: ${{ env.WIT_BINDGEN_VERSION }}"
+          echo "expected version: ${{ matrix.version }}, found: ${{ env.WIT_BINDGEN_VERSION }}"
+          exit 1
+
+  setup-v-version:
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version: ["0.16.0", "0.19.0"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Retrieve saved Github action
+        uses: actions/download-artifact@v3
+        with:
+          name: setup-wit-bindgen
+          path: dist/wit-bindgen/setup/
+
+      - name: setup wit-bindgen with v-prefixed version
+        uses: ./wit-bindgen/setup/
+        with:
+          version: v${{ matrix.version }}
+          github_token: ${{ github.token }}
+
+      - name: wit-bindgen setup successful
+        if: ${{ contains(env.WIT_BINDGEN_VERSION, matrix.version) }}
+        run: echo "wit-bindgen setup successful"
+
+      - name: wit-bindgen setup failed
+        if: ${{ !contains(env.WIT_BINDGEN_VERSION, matrix.version) }}
+        run: |
+          echo "expected version: ${{ matrix.version }}, found: ${{ env.WIT_BINDGEN_VERSION }}"
           exit 1

--- a/README.md
+++ b/README.md
@@ -1,29 +1,30 @@
 # bytecodelliance/actions
 
-With the `bytecodealliance/actions` collection, you can easily setup [wasmtime](https://github.com/bytecodealliance/wasmtime) and [wasm-tools](https://github.com/bytecodealliance/wasm-tools) in your [GitHub Action](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow). 
+With the `bytecodealliance/actions` collection, you can easily setup [wasmtime](https://github.com/bytecodealliance/wasmtime), [wasm-tools](https://github.com/bytecodealliance/wasm-tools), and [wit-bindgen](https://github.com/bytecodealliance/wit-bindgen) in your [GitHub Action](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow).
 
 This collection of Actions enables the following use cases:
 
-- [x] set up wasmtime using [`bytecodealliance/actions/wasmtime/setup@v1`](#install-wasmtime)
-- [x] set up wasm-tools using [`bytecodealliance/actions/wasm-tools/setup@v1`](#install-wasm-tools)
+- [x] set up `wasmtime` using [`bytecodealliance/actions/wasmtime/setup@v1`](#install-wasmtime)
+- [x] set up `wasm-tools` using [`bytecodealliance/actions/wasm-tools/setup@v1`](#install-wasm-tools)
+- [x] set up `wit-bindgen` using [`bytecodealliance/actions/wit-bindgen/setup@v1`](#install-wit-bindgen)
 
-Let's take a look at each one to learn about the required inputs and walk through an example. 
+Let’s take a look at each one to learn about the required inputs and walk through an example.
 
-## Install wasmtime
+## Install `wasmtime`
 
 ### Inputs
 
 | Name         | Required | Default | Description                                                                                                                                 |
 | ------------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| version      | False    | latest  | The version of `wasmtime` to install.                                                                                                           |
-| github_token | False    | -       | The GitHub token for querying/downloading `wasmtime` releases. If provided, it avoids GitHub API rate limiting during GitHub action executions |
+| `version`      | False    | `latest`  | The version of `wasmtime` to install.                                                                                                           |
+| `github_token` | False    | -       | The GitHub token for querying/downloading `wasmtime` releases. If provided, it avoids GitHub API rate limiting during GitHub action executions |
 
 ### Examples
 
-#### Setting up the latest version of `wasmtime` 
+#### Setting up the latest version of `wasmtime`
 
 ```yaml
-name: wasmtime setup
+name: wasmtime
 
 on:
   push:
@@ -42,7 +43,7 @@ jobs:
         run: "wasmtime --version"
 ```
 
-#### Setting up a specific version of `wasmtime` 
+#### Setting up a specific version of `wasmtime`
 
 ```yaml
 name: wasmtime
@@ -59,28 +60,27 @@ jobs:
       - name: Setup `wasmtime`
         uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
-          version: "v13.0.0"
+          version: "18.0.1"
 
       - name: Run `wasmtime version`
         run: "wasmtime --version"
 ```
 
-
-## Install wasm-tools
+## Install `wasm-tools`
 
 ### Inputs
 
 | Name         | Required | Default | Description                                                                                                                                 |
 | ------------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| version      | False    | latest  | The version of `wasm-tools` to install.                                                                                                           |
-| github_token | False    | -       | The GitHub token for querying/downloading `wasm-tools` releases. If provided, it avoids GitHub API rate limiting during GitHub action executions |
+| `version`      | False    | `latest`  | The version of `wasm-tools` to install.                                                                                                           |
+| `github_token` | False    | -       | The GitHub token for querying/downloading `wasm-tools` releases. If provided, it avoids GitHub API rate limiting during GitHub action executions |
 
 ### Examples
 
-#### Setting up the latest version of `wasm-tools` 
+#### Setting up the latest version of `wasm-tools`
 
 ```yaml
-name: wasm-tools setup
+name: wasm-tools
 
 on:
   push:
@@ -98,7 +98,7 @@ jobs:
         run: "wasm-tools --version"
 ```
 
-#### Setting up a specific version of `wasm-tools` 
+#### Setting up a specific version of `wasm-tools`
 
 ```yaml
 name: wasm-tools
@@ -119,4 +119,59 @@ jobs:
 
       - name: Run `wasm-tools version`
         run: "wasm-tools --version"
+```
+
+## Install `wit-bindgen`
+
+### Inputs
+
+| Name         | Required | Default | Description                                                                                                                                 |
+| ------------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`      | False    | `latest`  | The version of `wit-bindgen` to install.                                                                                                           |
+| `github_token` | False    | -       | The GitHub token for querying/downloading `wit-bindgen` releases. If provided, it avoids GitHub API rate limiting during GitHub action executions |
+
+### Examples
+
+#### Setting up the latest version of `wit-bindgen`
+
+```yaml
+name: wit-bindgen
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    name: Setup wit-bindgen
+    steps:
+      - name: Setup `wit-bindgen`
+        uses: bytecodealliance/actions/wit-bindgen/setup@v1
+
+      - name: Run `wit-bindgen version`
+        run: "wit-bindgen --version"
+```
+
+#### Setting up a specific version of `wit-bindgen`
+
+```yaml
+name: wit-bindgen
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    name: Setup wit-bindgen
+    steps:
+      - name: Setup `wit-bindgen`
+        uses: bytecodealliance/actions/wit-bindgen/setup@v1
+        with:
+          version: "0.19.0"
+
+      - name: Run `wit-bindgen version`
+        run: "wit-bindgen --version"
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bytecodelliance/actions
 
-With the `bytecodealliance/actions` collection, you can easily setup [wasmtime](https://github.com/bytecodealliance/wasmtime), [wasm-tools](https://github.com/bytecodealliance/wasm-tools), and [wit-bindgen](https://github.com/bytecodealliance/wit-bindgen) in your [GitHub Action](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow).
+With the `bytecodealliance/actions` collection, you can easily set up [`wasmtime`](https://github.com/bytecodealliance/wasmtime), [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools), and [`wit-bindgen`](https://github.com/bytecodealliance/wit-bindgen) in your [GitHub Actions](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow) workflow.
 
 This collection of Actions enables the following use cases:
 

--- a/dist/wasm-tools/setup/index.js
+++ b/dist/wasm-tools/setup/index.js
@@ -16964,7 +16964,7 @@ exports.getArch = getArch;
 
 /***/ }),
 
-/***/ 3263:
+/***/ 8389:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -17011,8 +17011,15 @@ function run() {
             const tag = yield (0, action_1.resolveVersion)(github_1.WASMTIME_ORG, github_1.WASM_TOOLS_REPO);
             // wasm-tools releases have a prefix of wasm-tools
             // therefore remove wasm-tools prefix to get just version
-            const version = tag.replace('wasm-tools-', '');
-            const downloadLink = yield (0, action_1.getDownloadLink)(github_1.WASMTIME_ORG, github_1.WASM_TOOLS_REPO, `wasm-tools-${version}`);
+            const version = tag.replace('wasm-tools-', '').replace(/^v/, '');
+            let downloadLink;
+            try {
+                downloadLink = yield (0, action_1.getDownloadLink)(github_1.WASMTIME_ORG, github_1.WASM_TOOLS_REPO, `v${version}`);
+            }
+            catch (error) {
+                // Try legacy tag format
+                downloadLink = yield (0, action_1.getDownloadLink)(github_1.WASMTIME_ORG, github_1.WASM_TOOLS_REPO, `wasm-tools-${version}`);
+            }
             const binName = 'wasm-tools';
             yield (0, action_1.download)(binName, version, downloadLink);
             yield (0, action_1.verify)(binName);
@@ -17238,7 +17245,7 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(3263);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(8389);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/dist/wasmtime/setup/index.js
+++ b/dist/wasmtime/setup/index.js
@@ -17008,7 +17008,8 @@ const action_1 = __nccwpck_require__(7672);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const version = yield (0, action_1.resolveVersion)(github_1.WASMTIME_ORG, github_1.WASMTIME_REPO);
+            const tag = yield (0, action_1.resolveVersion)(github_1.WASMTIME_ORG, github_1.WASMTIME_REPO);
+            const version = `v${tag.replace(/^v/, '')}`;
             const downloadLink = yield (0, action_1.getDownloadLink)(github_1.WASMTIME_ORG, github_1.WASMTIME_REPO, version);
             const binName = 'wasmtime';
             yield (0, action_1.download)(binName, version, downloadLink);

--- a/dist/wit-bindgen/setup/index.js
+++ b/dist/wit-bindgen/setup/index.js
@@ -17011,10 +17011,19 @@ function run() {
             const tag = yield (0, action_1.resolveVersion)(github_1.WASMTIME_ORG, github_1.WIT_BINDGEN_REPO);
             // wit-bindgen releases have a prefix of wit-bindgen-cli
             // therefore remove wit-bindgen-cli prefix to get just version
-            const version = tag.replace('wit-bindgen-cli-', '');
-            const downloadLink = yield (0, action_1.getDownloadLink)(github_1.WASMTIME_ORG, github_1.WIT_BINDGEN_REPO, `wit-bindgen-cli-${version}`);
+            const version = tag.replace('wit-bindgen-cli-', '').replace(/^v/, '');
+            let binVersion = version;
+            let downloadLink;
+            try {
+                downloadLink = yield (0, action_1.getDownloadLink)(github_1.WASMTIME_ORG, github_1.WIT_BINDGEN_REPO, `v${version}`);
+            }
+            catch (error) {
+                // Try legacy tag format
+                downloadLink = yield (0, action_1.getDownloadLink)(github_1.WASMTIME_ORG, github_1.WIT_BINDGEN_REPO, `wit-bindgen-cli-${version}`);
+                binVersion = `v${version}`;
+            }
             const binName = 'wit-bindgen';
-            yield (0, action_1.download)(binName, `v${version}`, downloadLink);
+            yield (0, action_1.download)(binName, binVersion, downloadLink);
             yield (0, action_1.verify)(binName);
         }
         catch (error) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "format": "prettier --write '**/*.ts'",
     "format-check": "prettier --check '**/*.ts'",
     "lint": "eslint src/**/*.ts",
-    "package": "ncc build -o dist/wasmtime/setup src/wasmtime.ts && ncc build -o dist/wasm-tools/setup src/wasmtools.ts && ncc build -o dist/wit-bindgen/setup src/wit-bindgen.ts",
+    "package": "ncc build -o dist/wasmtime/setup src/wasmtime.ts && ncc build -o dist/wasm-tools/setup src/wasm-tools.ts && ncc build -o dist/wit-bindgen/setup src/wit-bindgen.ts",
     "test": "jest",
     "all": "npm run build && npm run format && npm run package"
   },

--- a/src/wasm-tools.ts
+++ b/src/wasm-tools.ts
@@ -8,13 +8,23 @@ async function run(): Promise<void> {
 
     // wasm-tools releases have a prefix of wasm-tools
     // therefore remove wasm-tools prefix to get just version
-    const version = tag.replace('wasm-tools-', '')
+    const version = tag.replace('wasm-tools-', '').replace(/^v/, '')
 
-    const downloadLink = await getDownloadLink(
-      WASMTIME_ORG,
-      WASM_TOOLS_REPO,
-      `wasm-tools-${version}`
-    )
+    let downloadLink
+    try {
+      downloadLink = await getDownloadLink(
+        WASMTIME_ORG,
+        WASM_TOOLS_REPO,
+        `v${version}`
+      )
+    } catch (error) {
+      // Try legacy tag format
+      downloadLink = await getDownloadLink(
+        WASMTIME_ORG,
+        WASM_TOOLS_REPO,
+        `wasm-tools-${version}`
+      )
+    }
 
     const binName = 'wasm-tools'
     await download(binName, version, downloadLink)

--- a/src/wasmtime.ts
+++ b/src/wasmtime.ts
@@ -4,7 +4,8 @@ import {download, getDownloadLink, resolveVersion, verify} from './action'
 
 async function run(): Promise<void> {
   try {
-    const version = await resolveVersion(WASMTIME_ORG, WASMTIME_REPO)
+    const tag = await resolveVersion(WASMTIME_ORG, WASMTIME_REPO)
+    const version = `v${tag.replace(/^v/, '')}`
     const downloadLink = await getDownloadLink(
       WASMTIME_ORG,
       WASMTIME_REPO,

--- a/src/wit-bindgen.ts
+++ b/src/wit-bindgen.ts
@@ -8,16 +8,28 @@ async function run(): Promise<void> {
 
     // wit-bindgen releases have a prefix of wit-bindgen-cli
     // therefore remove wit-bindgen-cli prefix to get just version
-    const version = tag.replace('wit-bindgen-cli-', '')
+    const version = tag.replace('wit-bindgen-cli-', '').replace(/^v/, '')
+    let binVersion = version
 
-    const downloadLink = await getDownloadLink(
-      WASMTIME_ORG,
-      WIT_BINDGEN_REPO,
-      `wit-bindgen-cli-${version}`
-    )
+    let downloadLink
+    try {
+      downloadLink = await getDownloadLink(
+        WASMTIME_ORG,
+        WIT_BINDGEN_REPO,
+        `v${version}`
+      )
+    } catch (error) {
+      // Try legacy tag format
+      downloadLink = await getDownloadLink(
+        WASMTIME_ORG,
+        WIT_BINDGEN_REPO,
+        `wit-bindgen-cli-${version}`
+      )
+      binVersion = `v${version}`
+    }
 
     const binName = 'wit-bindgen'
-    await download(binName, `v${version}`, downloadLink)
+    await download(binName, binVersion, downloadLink)
     await verify(binName)
   } catch (error) {
     if (error instanceof Error) core.setFailed(error.message)


### PR DESCRIPTION
Fixes #8.

- Loads from legacy and new tag formats
- For consistency, all setup scripts now accept a version spec of `v1.0.0` or `1.0.0`
- I renamed CI test job names for readability in the GitHub UI