### PR TITLE
feat: add riscv64 architecture support

### DIFF
--- a/dist/wasm-tools/setup/index.js
+++ b/dist/wasm-tools/setup/index.js
@@ -16984,6 +16984,8 @@ function getArch() {
             return 'aarch64';
         case 'x64':
             return 'x86_64';
+        case 'riscv64':
+            return 'riscv64gc';
         default:
             throw new Error(`Unsupported operating system architecture: ${arch}`);
     }

--- a/dist/wasmtime/setup/index.js
+++ b/dist/wasmtime/setup/index.js
@@ -16984,6 +16984,8 @@ function getArch() {
             return 'aarch64';
         case 'x64':
             return 'x86_64';
+        case 'riscv64':
+            return 'riscv64gc';
         default:
             throw new Error(`Unsupported operating system architecture: ${arch}`);
     }

--- a/dist/wit-bindgen/setup/index.js
+++ b/dist/wit-bindgen/setup/index.js
@@ -16984,6 +16984,8 @@ function getArch() {
             return 'aarch64';
         case 'x64':
             return 'x86_64';
+        case 'riscv64':
+            return 'riscv64gc';
         default:
             throw new Error(`Unsupported operating system architecture: ${arch}`);
     }

--- a/src/system.ts
+++ b/src/system.ts
@@ -29,6 +29,8 @@ export function getArch(): string {
       return 'aarch64'
     case 'x64':
       return 'x86_64'
+    case 'riscv64':
+      return 'riscv64gc'
     default:
       throw new Error(`Unsupported operating system architecture: ${arch}`)
   }


### PR DESCRIPTION
Map Node.js `riscv64` arch to `riscv64gc` to match the release asset naming used by wasmtime, wasm-tools, and wit-bindgen.

## Problem

On riscv64 runners, `os.arch()` returns `'riscv64'`, which hits the default `throw` in `getArch()`:

```
Error: Unsupported operating system architecture: riscv64
```

This blocks any workflow using `bytecodealliance/actions/wasmtime/setup` on riscv64, even when wasmtime itself ships riscv64 binaries.

## Fix

Add a `case 'riscv64': return 'riscv64gc'` mapping in `src/system.ts`. The suffix `gc` matches the target triple used in release assets since wasmtime v27 (e.g. `wasmtime-v43.0.0-riscv64gc-linux.tar.xz`).

The same mapping applies to wasm-tools and wit-bindgen, whose assets follow the same naming convention.

## Context

Native riscv64 GitHub Actions runners are available through the [RISE Project](https://github.com/apps/rise-risc-v-runners) (label: `ubuntu-24.04-riscv`), free for open source projects. This fix allows projects like wasi-sdk to run their full CI on native riscv64 hardware.